### PR TITLE
Replaced default base URL (.fr to .eu)

### DIFF
--- a/pyeupi/api.py
+++ b/pyeupi/api.py
@@ -20,7 +20,7 @@ class InvalidSearchQuery(EUPIException):
 
 class PyEUPI(object):
 
-    def __init__(self, auth_token: str, url: str='https://phishing-initiative.fr',
+    def __init__(self, auth_token: str, url: str='https://phishing-initiative.eu',
                  verify_ssl: bool=True, debug: bool=False):
         self.url: str = url
         self.debug: bool = debug


### PR DESCRIPTION
The default base URL for the API, in the source code, is currently `https://phishing-initiative.fr`. However, Phishing Initiative domain is now `https://phishing-initiative.eu`, which makes the interaction and authentication with PyEUPI not work if the new domain is not specified when calling PyEUPI constructor.

This pull request fixes the default domain in the library code.